### PR TITLE
Add new path get_image_fullname if domain is empty

### DIFF
--- a/scripts/1_scan_images.py
+++ b/scripts/1_scan_images.py
@@ -48,7 +48,10 @@ def get_image_fullname(domain: str, path: str,
     @param path: The path the image can be found at
     @param tag: The tag of the image.
     """
-    return f"{domain}/{path}:{tag}"
+    if domain == "":
+        return f"{path}:{tag}"
+    else:
+        return f"{domain}/{path}:{tag}"
 
 
 def _rm_image(image_fullname: str):


### PR DESCRIPTION
This slight change got me up and running for the newest analysis of Iron Bank images.

```python

    if domain == "":
        return f"{path}:{tag}"
    else:
        return f"{domain}/{path}:{tag}"
```

I don't think this PR *hurts* anything, but don't feel a need to merge it. I just wanted to show you how this dumb user felt pain--what pain exactly--and how I fixed it.